### PR TITLE
Fixed a bug that caused reading multi-dimensional arrays to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] - 0.05.2020
+## [1.5.1] - 08.05.2020
 ### Changed
 - Fixed a bug that caused reading multi-dimensional arrays to fail if they are part of a struct and not the last struct element ([See issue #10 comment](https://github.com/jisotalo/ads-client/issues/10#issuecomment-640470603))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 0.05.2020
+### Changed
+- Fixed a bug that caused reading multi-dimensional arrays to fail if they are part of a struct and not the last struct element ([See issue #10 comment](https://github.com/jisotalo/ads-client/issues/10#issuecomment-640470603))
+
 ## [1.5.0] - 30.05.2020
 ### Added
 - `WriteControl()` method for connecting device states using ADS WriteControl command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.5.1] - 08.05.2020
+## [1.5.1] - 08.06.2020
 ### Changed
 - Fixed a bug that caused reading multi-dimensional arrays to fail if they are part of a struct and not the last struct element ([See issue #10 comment](https://github.com/jisotalo/ads-client/issues/10#issuecomment-640470603))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ads-client",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Unofficial Node.js library for connecting to Beckhoff TwinCAT automation systems using ADS protocol",
   "main": "./src/ads-client.js",
   "scripts": {

--- a/src/ads-client.js
+++ b/src/ads-client.js
@@ -4118,7 +4118,8 @@ function _parsePlcDataToObject(dataBuffer, dataType, isArraySubItem = false) {
       output[subItem.name] = _parsePlcDataToObject.call(this, dataBuffer, subItem)
 
       if (subItem.arrayData.length > 0) {
-        dataBuffer = dataBuffer.slice(subItem.size * subItem.arrayData[0].length)
+        //Calculate total array size in bytes
+        dataBuffer = dataBuffer.slice(subItem.size * subItem.arrayData.reduce((total, value) => total * value.length, 1))
       } else {
         dataBuffer = dataBuffer.slice(subItem.size)
       }
@@ -4127,11 +4128,11 @@ function _parsePlcDataToObject(dataBuffer, dataType, isArraySubItem = false) {
   //Array - Go through each array subitem
   } else if (dataType.arrayData.length > 0 && !isArraySubItem) {
     output = []
-
+    
     //Recursive parsing of array dimensions
     const parseArray = (arrayDimension) => {
       let result = []
-
+      
       for (let child = 0; child < dataType.arrayData[arrayDimension].length; child++) {
         if (dataType.arrayData[arrayDimension + 1]) {
           //More dimensions available -> go deeper


### PR DESCRIPTION
## [1.5.1] - 0.05.2020
### Changed
- Fixed a bug that caused reading multi-dimensional arrays to fail if they are part of a struct and not the last struct element ([See issue #10 comment](https://github.com/jisotalo/ads-client/issues/10#issuecomment-640470603))
