### PR TITLE
Correct typo "Susped" in `ADS_STATE`

### DIFF
--- a/src/ads-client-ads.js
+++ b/src/ads-client-ads.js
@@ -486,7 +486,7 @@ const ADS_STATE = {
   PowerGood: 10,
   Error: 11,
   Shutdown: 12,
-  Susped: 13,
+  Suspend: 13,
   Resume: 14,
   Config: 15,
   Reconfig: 16,


### PR DESCRIPTION
In case users rely on `adsStateStr` being reported as `Susped`, this would be a breaking change.

If you deem it's not worthwhile to correct the typo, feel free to close the pull request.