### PR TITLE
Add type INTERFACE parsing support

### DIFF
--- a/src/ads-client-ads.js
+++ b/src/ads-client-ads.js
@@ -1090,6 +1090,16 @@ const BASE_DATA_TYPES = {
           return buffer
       }
     },
+    {
+      name: ['INTERFACE'],
+      adsDataType: ADS_DATA_TYPES.ADST_VOID,
+      size: 0,
+      toBuffer: (value, buffer, settings) => {
+      },
+      fromBuffer: (buffer, settings) => {
+          return null
+      }
+    },
   ],
 
 
@@ -1156,6 +1166,13 @@ const BASE_DATA_TYPES = {
       actualTypesBySize: {
         4: 'DWORD',
         8: 'LWORD'
+      }
+    },
+    {
+      name: ['INTERFACE', 'I_'],
+      actualTypesBySize: {
+        4: 'INTERFACE',
+        8: 'INTERFACE'
       }
     },
   ]


### PR DESCRIPTION
Treat type of INTERFACE as VOID, let it takes 0 bytes and return null to JSON. ( Those symbol name stats with 'I_' )