### PR TITLE
(v2-dev) Declare `Client` event types

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "@types/node": "^18.16.2",
     "debug": "^4.3.3",
     "iconv-lite": "^0.6.3",
-    "long": "^5.2.0"
+    "long": "^5.2.0",
+    "tiny-typed-emitter": "^2.1.0"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.3",

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "events";
+import { TypedEmitter } from 'tiny-typed-emitter';
 import type { ActiveAdsRequestContainer, ActiveSubscription, ActiveSubscriptionContainer, AdsClientConnection, AdsClientSettings, AdsCommandToSend, AdsDataTypeContainer, AdsSymbolInfoContainer, AdsUploadInfo, ConnectionMetaData, PlcPrimitiveType, SubscriptionCallback, SubscriptionData, SubscriptionSettings, ReadSymbolResult, TimerObject, ObjectToBufferConversionResult, WriteSymbolResult, VariableHandle } from "./types/ads-client-types";
 import { AdsAddNotificationResponse, AdsAddNotificationResponseData, AdsArrayInfoEntry, AdsAttributeEntry, AdsDataType, AdsDeleteNotificationResponse, AdsDeviceInfo, AdsEnumInfoEntry, AdsNotification, AdsNotificationResponse, AdsNotificationSample, AdsNotificationStamp, AdsRawInfo, AdsReadDeviceInfoResponse, AdsReadResponse, AdsReadStateResponse, AdsReadWriteResponse, AdsRequest, AdsResponse, AdsRpcMethodEntry, AdsRpcMethodParameterEntry, AdsState, AdsSymbolInfo, AdsWriteControlResponse, AdsWriteResponse, AmsAddress, AmsHeader, AmsPortRegisteredData, AmsRouterState, AmsRouterStateData, AmsTcpHeader, AmsTcpPacket, BaseAdsResponse, EmptyAdsResponse, UnknownAdsResponse } from "./types/ads-protocol-types";
 import {
@@ -20,7 +20,18 @@ const die = (...args: any) => {
   process.exit();
 }
 
-export class Client extends EventEmitter {
+interface ClientEvents {
+  'connect': (connection: AdsClientConnection) => void;
+  'disconnect': () => void;
+  'connectionLost': () => void;
+  'reconnect': () => void;
+  'symbolVersionChange': (version: number) => void;
+  'plcRuntimeStateChange': (state: AdsState) => void;
+  'routerStateChange': (state: AmsRouterState) => void;
+  'ads-client-error': (error: ClientError) => void;
+}
+
+export class Client extends TypedEmitter<ClientEvents> {
   private debug = Debug("ads-client");
   private debugD = Debug(`ads-client:details`);
   private debugIO = Debug(`ads-client:raw-data`);


### PR DESCRIPTION
This [no-overhead](https://github.com/binier/tiny-typed-emitter?tab=readme-ov-file#no-overhead) change adds type information for `Client` events and handlers.