### PR TITLE
(v2-dev) Export interfaces

### DIFF
--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -12,7 +12,7 @@ import * as ADS from './ads-commons';
 import ClientError from "./client-error";
 export * as ADS from './ads-commons';
 export type { AdsClientSettings } from "./types/ads-client-types";
-export type { AdsState, AmsRouterState } from "./types/ads-protocol-types";
+export type { AdsState, AmsRouterState, AdsResponse, EmptyAdsResponse, UnknownAdsResponse, AdsReadResponse, AdsReadWriteResponse, AdsWriteResponse, AdsReadDeviceInfoResponse, AdsNotificationResponse, AdsAddNotificationResponse, AdsDeleteNotificationResponse, AdsWriteControlResponse } from "./types/ads-protocol-types";
 
 //TODO: Remove this (only for v2 development use)
 const die = (...args: any) => {

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -11,6 +11,8 @@ import Long from "long";
 import * as ADS from './ads-commons';
 import ClientError from "./client-error";
 export * as ADS from './ads-commons';
+export type { AdsClientSettings } from "./types/ads-client-types";
+export type { AdsState, AmsRouterState } from "./types/ads-protocol-types";
 
 //TODO: Remove this (only for v2 development use)
 const die = (...args: any) => {

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -907,7 +907,7 @@ export class Client extends EventEmitter {
    * 
    * @template T ADS response type. If omitted, generic AdsResponse is used
    */
-  private async sendAdsCommand<T = AdsResponse>(command: AdsCommandToSend) {
+  async sendAdsCommand<T = AdsResponse>(command: AdsCommandToSend) {
     return new Promise<AmsTcpPacket<T>>(async (resolve, reject) => {
 
       if (this.nextInvokeId >= ADS.ADS_INVOKE_ID_MAX_VALUE) {


### PR DESCRIPTION
I suggest exporting these useful interfaces:
- `AdsClientSettings` for declaring settings in client code.
- `AdsState` and `AmsRouterState` for event handling in client code.