### PR TITLE
(v2) add `warning` event

### DIFF
--- a/src/types/ads-client-types.ts
+++ b/src/types/ads-client-types.ts
@@ -84,6 +84,16 @@ export interface ClientEvents {
    * - `error`: Error that was thrown
    */
   'client-error': [error: ClientError]
+
+  /**
+   * Emitted when the client encounters non-critical abnormal events, such as
+   *  - connected to a non-running TwinCAT system
+   *  - re-connection attempted after connection loss
+   *  - lost connection re-established
+   *
+   * - `message`: Warning message
+   */
+  'warning': [message: string]
 }
 
 /**


### PR DESCRIPTION
Proposal for #151:
- Extracts `!this.settings.hideConsoleWarnings && console.log(...)` as a `warn(message: string)` method.
- Adds a `warning` event, which is always emitted on warnings (whereas `console.log()` is conditional on `!this.settings.hideConsoleWarnings`).

