### PR TITLE
Let `unregisterAdsPort` resolve when `AMS_TCP_PORT_CLOSE` is received

### DIFF
--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -913,6 +913,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
         this.amsTcpCallback = undefined;
         if (res.amsTcp.command === ADS.AMS_HEADER_FLAG.AMS_TCP_PORT_CLOSE) {
           this.debug(`unregisterAdsPort(): ADS port unregistered`);
+          this.socket?.destroy();
           resolve();
         }
       }

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -837,7 +837,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
       this.socket?.once('error', errorHandler);
 
       try {
-        await this.socketWrite(packet);
+        this.socketWrite(packet);
 
       } catch (err) {
         this.socket?.off('error', errorHandler);
@@ -910,7 +910,8 @@ export class Client extends EventEmitter<AdsClientEvents> {
       });
 
       try {
-        await this.socketWrite(buffer);
+        this.socketWrite(buffer);
+        resolve();
       } catch (err) {
         reject(err);
       }

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -905,12 +905,16 @@ export class Client extends EventEmitter<AdsClientEvents> {
       //Sometimes close event is not received, so resolve already here
       this.socket.once('end', () => {
         this.debugD(`unregisterAdsPort(): Socket connection ended, connection closed.`);
+        clearTimeout(this.portRegisterTimeoutTimer);
+        this.amsTcpCallback = undefined;
         this.socket?.destroy();
         resolve();
       });
 
       this.amsTcpCallback = (res: AmsTcpPacket) => {
         this.amsTcpCallback = undefined;
+        clearTimeout(this.portRegisterTimeoutTimer);
+
         if (res.amsTcp.command === ADS.AMS_HEADER_FLAG.AMS_TCP_PORT_CLOSE) {
           this.debug(`unregisterAdsPort(): ADS port unregistered`);
           this.socket?.destroy();
@@ -940,7 +944,8 @@ export class Client extends EventEmitter<AdsClientEvents> {
       } catch (err) {
         reject(err);
       } finally {
-        this.portRegisterTimeoutTimer && clearTimeout(this.portRegisterTimeoutTimer);
+        this.amsTcpCallback = undefined;
+        clearTimeout(this.portRegisterTimeoutTimer);
       }
     })
   }


### PR DESCRIPTION
Possible fix for #157.

Also, `this.socketWrite()` is not asynchronous, so `await` doesn't have any effect.