### PR TITLE
(v2-dev) `unregisterAdsPort`: Avoid removing callback before response is received

### DIFF
--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -942,10 +942,9 @@ export class Client extends EventEmitter<AdsClientEvents> {
       try {
         this.socketWrite(buffer);
       } catch (err) {
-        reject(err);
-      } finally {
         this.amsTcpCallback = undefined;
         clearTimeout(this.portRegisterTimeoutTimer);
+        reject(err);
       }
     })
   }


### PR DESCRIPTION
With connection [Setup 2](https://github.com/jisotalo/ads-client?tab=readme-ov-file#setup-2---connecting-from-unixwindowsetc-system-to-the-plc) (local `AdsRouterConsole`), I observed that `disconnect()` hangs because `unregisterAdsPort()` fails to resolve.

As far as I can tell, the reason is that the `amsTcpCallback` is cleared _before_ the "port unregister response" is received:

<img width="1281" alt="image" src="https://github.com/user-attachments/assets/e6ba3bc4-3c73-4157-b833-4f3215a80655">

In `unregisterAdsPort()`, the callback gets cleared as soon as the `AMS_TCP_PORT_CLOSE` packet is sent:

```ts
      try {
        this.socketWrite(buffer);
      } catch (err) {
        reject(err);
      } finally {
        this.amsTcpCallback = undefined; // ⚠️ Callback removed too soon?
        clearTimeout(this.portRegisterTimeoutTimer);
      }
```

The patch here seems to address the issue — callback gets called and `unregisterAdsPort()` resolves:

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/67e331fe-c118-4a78-8006-644a30d3eb39">
