### PR TITLE
(v2) Configurable target `AMS_NET_ID` in tests

### DIFF
--- a/test/TC2/ads-client.test.js
+++ b/test/TC2/ads-client.test.js
@@ -32,8 +32,9 @@ About this test file:
  * This must match with .VERSION
  */
 const PLC_PROJECT_VERSION = '2.0.0';
-const AMS_NET_ID = '5.19.100.19.1.1';
 
+const AMS_NET_ID = process.env.AMS_NET_ID ?? '5.19.100.19.1.1';
+const LOCAL_AMS_NET_ID = process.env.LOCAL_AMS_NET_ID ?? '192.168.68.101.1.1';
 
 const { Client, ADS } = require('../../dist/ads-client');
 const util = require('util');
@@ -89,7 +90,7 @@ describe('connection', () => {
     expect(Object.keys(client.connection)).toStrictEqual(Object.keys({
       connected: true,
       isLocal: false,
-      localAmsNetId: '192.168.68.101.1.1',
+      localAmsNetId: LOCAL_AMS_NET_ID,
       localAdsPort: 32891,
       targetAmsNetId: client.settings.targetAmsNetId,
       targetAdsPort: 851

--- a/test/TC3/ads-client.test.js
+++ b/test/TC3/ads-client.test.js
@@ -25,7 +25,9 @@ SOFTWARE.
  * This must match with GVL_AdsClientTests.VERSION
  */
 const PLC_PROJECT_VERSION = '2.0.0';
-const AMS_NET_ID = '192.168.4.1.1.1';
+
+const AMS_NET_ID = process.env.AMS_NET_ID ?? '192.168.4.1.1.1';
+const LOCAL_AMS_NET_ID = process.env.LOCAL_AMS_NET_ID ?? '192.168.68.101.1.1';
 
 const { Client, ADS } = require('../../dist/ads-client');
 const util = require('util');
@@ -82,7 +84,7 @@ describe('connection', () => {
     expect(Object.keys(client.connection)).toStrictEqual(Object.keys({
       connected: true,
       isLocal: false,
-      localAmsNetId: '192.168.68.101.1.1',
+      localAmsNetId: LOCAL_AMS_NET_ID,
       localAdsPort: 32891,
       targetAmsNetId: client.settings.targetAmsNetId,
       targetAdsPort: 851


### PR DESCRIPTION
I propose allowing target `AMS_NET_ID` and `LOCAL_AMS_NET_ID` in `test/*` to be overridden by environment variables, to make it easier to run the tests in different network environments.
