### PR TITLE
fix: catch without argument does not suppress

### DIFF
--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -747,7 +747,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
 
       if (this.socket) {
         this.debug(`reconnectToTarget(): Trying to disconnect`);
-        await this.disconnectFromTarget(forceDisconnect, isReconnecting).catch();
+        await this.disconnectFromTarget(forceDisconnect, isReconnecting).catch(() => {});
       }
       this.debug(`reconnectToTarget(): Trying to connect...`);
       return this.connectToTarget(true)
@@ -1297,7 +1297,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
 
     if (this.settings.autoReconnect !== true) {
       this.warn("Connection to target was lost and setting autoReconnect was false -> disconnecting");
-      await this.disconnectFromTarget(true).catch();
+      await this.disconnectFromTarget(true).catch(() => {});
       return;
     }
 


### PR DESCRIPTION
Occasionally I see unhandled promise rejections during auto-reconnect:

```
Unhandled promise rejection: Promise { <rejected> } reason: 562 |                 this.activeSubscriptions = {};
563 |                 this.debug(`disconnectFromTarget(): Connection closing failed, connection was forced to close`);
564 |                 if (isReconnecting) {
565 |                     this.emit("disconnect", isReconnecting);
566 |                 }
567 |                 return reject(new client_error_1.default(`disconnect(): Disconnected with errors: ${disconnectError.message}`, err));
                                                       ^
ClientError: disconnect(): Disconnected with errors: unregisterAdsPort(): Timeout - no response in 2000 ms
    trace: [
  "disconnect(): Disconnected with errors: unregisterAdsPort(): Timeout - no response in 2000 ms",
  "unregisterAdsPort(): Timeout - no response in 2000 ms"
],
 adsError: {
  errorCode: undefined,
  errorStr: undefined,
},
```

Likely because `.catch()` without argument does not suppress exceptions.