### PR TITLE
perf: cache fully built data types in `buildDataType()`

### DIFF
--- a/src/types/ads-client-types.ts
+++ b/src/types/ads-client-types.ts
@@ -583,6 +583,8 @@ export interface ConnectionMetaData {
   allPlcDataTypesCached: boolean,
   /** Cached target PLC runtime data types without subitems (if available) */
   plcDataTypes: AdsDataTypeContainer,
+  /** Cached fully built data types with all subitems resolved */
+  builtDataTypes: AdsDataTypeContainer,
   /** Set to `true` if target ADS symbols/datatypes are UTF-8 encoded (default in TwinCAT 4026 and newer) */
   adsSymbolsUseUtf8: boolean
 };


### PR DESCRIPTION
`buildDataType()` method is recursively rebuilding the full type hierarchy on every call, even though the underlying `getDataTypeDeclaration()` results are cached. 

This can cause significant CPU overhead with frequent ADS notifications.

This change adds a cache for the fully built data types (`builtDataTypes`), similar to the existing `plcDataTypes` cache:

- keyed by lowercase type name (matching existing convention)
- only caches root types (not intermediate recursive calls)
- respects the `disableCaching` setting
- is cleared when the PLC symbol version changes
