### PR TITLE
fix: fix variable shadowing in ExtendedEnumInfos attribute parser

### DIFF
--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -2911,7 +2911,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
         dataType.enumInfos[i].attributes = [];
 
         //Attributes
-        for (let i = 0; i < attributeCount; i++) {
+        for (let ai = 0; ai < attributeCount; ai++) {
           const attr = {} as AdsAttributeEntry;
 
           //Name length

--- a/test/TC3/ads-client.test.js
+++ b/test/TC3/ads-client.test.js
@@ -1240,6 +1240,21 @@ describe('reading values', () => {
           value: 2
         });
       }
+      {
+        // E_ExtendedEnum - checks per-member attributes (ExtendedEnumInfos flag, TC 4026+)
+        const res = await client.readValue('GVL_Read.ComplexTypes.ENUM_6');
+        expect(res.value).toMatchObject({
+          name: 'Unknown',
+          value: -99
+        });
+        expect(res.dataType.enumInfos).toMatchObject([
+          { name: 'Disabled', value: 0,   attributes: [{ name: 'color', value: 'grey' }] },
+          { name: 'Starting', value: 50,  attributes: [{ name: 'color', value: 'yellow' }] },
+          { name: 'Running',  value: 100, attributes: [{ name: 'color', value: 'green' }] },
+          { name: 'Stopping', value: 200, attributes: [{ name: 'color', value: 'orange' }] },
+          { name: 'Unknown',  value: -99, attributes: [{ name: 'ads-client-enum-attribute', value: 'example-enum-value-ääö' }, { name: 'color', value: 'red' }] },
+        ]);
+      }
     });
 
     test('reading POINTER (address)', async () => {


### PR DESCRIPTION
## Problem
Fixes [#185  ](https://github.com/jisotalo/ads-client/issues/185)

When parsing enum types with the `ExtendedEnumInfos` flag (per-member 
`{attribute}` pragmas, available on TC 3.1.4026+), the inner attribute 
loop used the same variable name `i` as the outer enum member loop. 
This shadowed the outer index, corrupting attribute assignment across 
enum entries.

## Fix
Renamed the inner loop variable from `i` to `ai` in the 
`ExtendedEnumInfos` parsing block (`src/ads-client.ts`).

## Test
Added regression test for `E_ExtendedEnum` (read as `ENUM_6`) which 
verifies all five enum members carry their correct per-member attributes 
after parsing.

Companion PR for the test PLC project: 
https://github.com/jisotalo/ads-client-test-plc-project/pulls

---
Thanks for maintaining this project — the documentation is really 
great and it's been a pleasure to work with. Keep it up 👍🏻 