### PR TITLE
Compiled decoders

### DIFF
--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -338,10 +338,13 @@ export class Client extends EventEmitter<AdsClientEvents> {
 
   /**
    * Cached compiled decoders (see `settings.useCompiledDecoders`), keyed by the cached
-   * data type object. A `WeakMap` follows the data type cache lifecycle automatically:
-   * when the metadata cache is cleared (reconnect, symbol version change), new data type
-   * objects are built and stale decoders are garbage collected. `undefined` is cached
-   * for data types the decoder compiler does not support.
+   * data type object. A `WeakMap` follows the built data type cache lifecycle: when
+   * `metaData.builtDataTypes` is replaced with a fresh object - as on a symbol version
+   * change - the data types are built again and the decoders compiled for the previous
+   * ones are garbage collected. This holds only as long as clearing the cache replaces
+   * the container instead of reusing it, so that a decoder can never outlive the data
+   * type it was compiled for. `undefined` is cached for data types the decoder compiler
+   * does not support.
    */
   private compiledDecoders = new WeakMap<AdsDataType, CompiledDecoder | undefined>();
 
@@ -3290,7 +3293,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
    *
    * The compiled decoder cache piggybacks on the built data type cache: it's a `WeakMap`
    * keyed by the cached `AdsDataType` object, so a decoder is compiled once per cached
-   * type and dropped when the metadata cache is cleared. This only works when
+   * type and dropped when that type is no longer cached. This only works when
    * `buildDataType()` actually returns cached (identical) objects, so the compiled path
    * is skipped whenever that caching does not apply:
    *

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -32,6 +32,7 @@ import Debug from "debug";
 import Long from "long";
 import * as ADS from './ads-commons';
 import ClientError from "./client-error";
+import { compileDataTypeDecoder, type CompiledDecoder } from "./compiled-decoder";
 
 import type {
   ActiveAdsRequestContainer,
@@ -306,7 +307,8 @@ export class Client extends EventEmitter<AdsClientEvents> {
     rawClient: false,
     disableCaching: false,
     deleteUnknownSubscriptions: true,
-    forceUtf8ForAdsSymbols: false
+    forceUtf8ForAdsSymbols: false,
+    useCompiledDecoders: false
   } as Required<AdsClientSettings>;
 
   /**
@@ -329,10 +331,19 @@ export class Client extends EventEmitter<AdsClientEvents> {
 
   /**
    * Container for all active subscriptions.
-   * 
+   *
    * Do not edit this directly.
    */
   public activeSubscriptions: ActiveSubscriptionContainer = {};
+
+  /**
+   * Cached compiled decoders (see `settings.useCompiledDecoders`), keyed by the cached
+   * data type object. A `WeakMap` follows the data type cache lifecycle automatically:
+   * when the metadata cache is cleared (reconnect, symbol version change), new data type
+   * objects are built and stale decoders are garbage collected. `undefined` is cached
+   * for data types the decoder compiler does not support.
+   */
+  private compiledDecoders = new WeakMap<AdsDataType, CompiledDecoder | undefined>();
 
   /**
    * Creates a new ADS client instance.
@@ -2174,7 +2185,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
 
           if (this.symbol) {
             const dataType = await clientRef.getDataType(this.symbol.type, this.targetOpts);
-            result.value = clientRef.convertBufferToObject<T>(data, dataType, this.symbol.attributes);
+            result.value = clientRef.decodeBufferToObject<T>(data, dataType, this.symbol.attributes);
           }
 
           this.latestData = result;
@@ -3273,10 +3284,47 @@ export class Client extends EventEmitter<AdsClientEvents> {
   }
 
   /**
-   * Converts raw data to Javascript object.
-   * 
-   * This is usually called recursively.
-   * 
+   * Converts raw data to a Javascript object, using a cached compiled decoder if
+   * `settings.useCompiledDecoders` is set (see {@link compileDataTypeDecoder}),
+   * otherwise using {@link Client.convertBufferToObject}. The result is identical.
+   *
+   * The compiled path is skipped when caching is disabled (compiling would then happen on
+   * every call) and when symbol attributes are provided that would affect decoding (string
+   * encoding) - the decoder cache is keyed by data type, which possibly multiple symbols
+   * with different attributes resolve to.
+   *
+   * @param data The raw data to convert
+   * @param dataType Target data type
+   * @param attributes Additional attributes of the symbol or data type used for conversion
+   */
+  private decodeBufferToObject<T = any>(data: Buffer, dataType: AdsDataType, attributes?: AdsAttributeEntry[]): T {
+    const attributesAffectDecoding = attributes?.some(attr => attr.name === 'TcEncoding');
+
+    if (this.settings.useCompiledDecoders && !this.settings.disableCaching && !attributesAffectDecoding) {
+      let decoder = this.compiledDecoders.get(dataType);
+
+      if (decoder === undefined && !this.compiledDecoders.has(dataType)) {
+        decoder = compileDataTypeDecoder(dataType, this.settings, attributes);
+        this.compiledDecoders.set(dataType, decoder);
+
+        if (!decoder) {
+          this.debug(`decodeBufferToObject(): Data type ${dataType.type} has unsupported constructs - converting without compiled decoder`);
+        }
+      }
+
+      if (decoder) {
+        return decoder(data) as T;
+      }
+    }
+
+    return this.convertBufferToObject<T>(data, dataType, attributes);
+  }
+
+  /**
+   * Converts raw data to a Javascript object by interpreting the data type metadata.
+   *
+   * See also {@link Client.decodeBufferToObject} for the compiled variant.
+   *
    * @param data The raw data to convert
    * @param dataType Target data type
    * @param attributes Additional attributes of the symbol or data type used for conversion
@@ -6489,7 +6537,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
     let value: T;
     try {
       this.debugD(`readValue(): Converting raw value to object for ${path}`);
-      value = await this.convertBufferToObject<T>(rawValue, dataType, symbol.attributes);
+      value = await this.decodeBufferToObject<T>(rawValue, dataType, symbol.attributes);
 
     } catch (err) {
       this.debug(`readValue(): Converting raw value to object for ${path} failed: %o`, err);
@@ -6809,7 +6857,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
     let value: T;
     try {
       this.debugD(`convertFromRaw(): Converting raw value to object for ${dataType.type}`);
-      value = await this.convertBufferToObject<T>(data, dataType, attributes);
+      value = await this.decodeBufferToObject<T>(data, dataType, attributes);
 
     } catch (err) {
       this.debug(`convertFromRaw(): Converting raw value to object for ${dataType.type} failed: %o`, err);

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -2185,7 +2185,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
 
           if (this.symbol) {
             const dataType = await clientRef.getDataType(this.symbol.type, this.targetOpts);
-            result.value = clientRef.decodeBufferToObject<T>(data, dataType, this.symbol.attributes);
+            result.value = clientRef.decodeBufferToObject<T>(data, dataType, this.symbol.attributes, this.targetOpts);
           }
 
           this.latestData = result;
@@ -3288,19 +3288,30 @@ export class Client extends EventEmitter<AdsClientEvents> {
    * `settings.useCompiledDecoders` is set (see {@link compileDataTypeDecoder}),
    * otherwise using {@link Client.convertBufferToObject}. The result is identical.
    *
-   * The compiled path is skipped when caching is disabled (compiling would then happen on
-   * every call) and when symbol attributes are provided that would affect decoding (string
-   * encoding) - the decoder cache is keyed by data type, which possibly multiple symbols
-   * with different attributes resolve to.
+   * The compiled decoder cache piggybacks on the built data type cache: it's a `WeakMap`
+   * keyed by the cached `AdsDataType` object, so a decoder is compiled once per cached
+   * type and dropped when the metadata cache is cleared. This only works when
+   * `buildDataType()` actually returns cached (identical) objects, so the compiled path
+   * is skipped whenever that caching does not apply:
+   *
+   * - `settings.disableCaching` is set (every call would compile from scratch - slower than interpreting)
+   * - `targetOpts` overrides the target (`buildDataType()` builds a fresh object per call - same reason)
+   *
+   * It is also skipped when symbol attributes are provided that would affect decoding
+   * (string encoding) - multiple symbols with different attributes can resolve to the
+   * same cached data type, and the cache is keyed by data type alone.
    *
    * @param data The raw data to convert
    * @param dataType Target data type
    * @param attributes Additional attributes of the symbol or data type used for conversion
+   * @param targetOpts Optional target settings that were used when resolving `dataType`
    */
-  private decodeBufferToObject<T = any>(data: Buffer, dataType: AdsDataType, attributes?: AdsAttributeEntry[]): T {
+  private decodeBufferToObject<T = any>(data: Buffer, dataType: AdsDataType, attributes?: AdsAttributeEntry[], targetOpts: Partial<AmsAddress> = {}): T {
+    //Same condition that gates the built data type cache in buildDataType()
+    const dataTypeIsCached = !this.settings.disableCaching && !targetOpts.adsPort && !targetOpts.amsNetId;
     const attributesAffectDecoding = attributes?.some(attr => attr.name === 'TcEncoding');
 
-    if (this.settings.useCompiledDecoders && !this.settings.disableCaching && !attributesAffectDecoding) {
+    if (this.settings.useCompiledDecoders && dataTypeIsCached && !attributesAffectDecoding) {
       let decoder = this.compiledDecoders.get(dataType);
 
       if (decoder === undefined && !this.compiledDecoders.has(dataType)) {
@@ -6537,7 +6548,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
     let value: T;
     try {
       this.debugD(`readValue(): Converting raw value to object for ${path}`);
-      value = await this.decodeBufferToObject<T>(rawValue, dataType, symbol.attributes);
+      value = await this.decodeBufferToObject<T>(rawValue, dataType, symbol.attributes, targetOpts);
 
     } catch (err) {
       this.debug(`readValue(): Converting raw value to object for ${path} failed: %o`, err);
@@ -6857,7 +6868,7 @@ export class Client extends EventEmitter<AdsClientEvents> {
     let value: T;
     try {
       this.debugD(`convertFromRaw(): Converting raw value to object for ${dataType.type}`);
-      value = await this.decodeBufferToObject<T>(data, dataType, attributes);
+      value = await this.decodeBufferToObject<T>(data, dataType, attributes, targetOpts);
 
     } catch (err) {
       this.debug(`convertFromRaw(): Converting raw value to object for ${dataType.type} failed: %o`, err);

--- a/src/ads-client.ts
+++ b/src/ads-client.ts
@@ -3297,9 +3297,11 @@ export class Client extends EventEmitter<AdsClientEvents> {
    * - `settings.disableCaching` is set (every call would compile from scratch - slower than interpreting)
    * - `targetOpts` overrides the target (`buildDataType()` builds a fresh object per call - same reason)
    *
-   * It is also skipped when symbol attributes are provided that would affect decoding
-   * (string encoding) - multiple symbols with different attributes can resolve to the
-   * same cached data type, and the cache is keyed by data type alone.
+   * It is also skipped when symbol attributes are provided that would affect decoding -
+   * multiple symbols with different attributes can resolve to the same cached data type,
+   * and the cache is keyed by data type alone. Like in `convertBufferToObject()`, symbol
+   * attributes only influence string encoding of the root type (subitems only see their
+   * own data type attributes), so only a `TcEncoding` attribute on a STRING root skips.
    *
    * @param data The raw data to convert
    * @param dataType Target data type
@@ -3309,7 +3311,8 @@ export class Client extends EventEmitter<AdsClientEvents> {
   private decodeBufferToObject<T = any>(data: Buffer, dataType: AdsDataType, attributes?: AdsAttributeEntry[], targetOpts: Partial<AmsAddress> = {}): T {
     //Same condition that gates the built data type cache in buildDataType()
     const dataTypeIsCached = !this.settings.disableCaching && !targetOpts.adsPort && !targetOpts.amsNetId;
-    const attributesAffectDecoding = attributes?.some(attr => attr.name === 'TcEncoding');
+    const attributesAffectDecoding = dataType.adsDataType === ADS.ADS_DATA_TYPES.ADST_STRING
+      && attributes?.some(attr => attr.name === 'TcEncoding');
 
     if (this.settings.useCompiledDecoders && dataTypeIsCached && !attributesAffectDecoding) {
       let decoder = this.compiledDecoders.get(dataType);

--- a/src/compiled-decoder.ts
+++ b/src/compiled-decoder.ts
@@ -17,6 +17,11 @@ export type CompiledDecoder = (data: Buffer) => any;
 
 /**
  * Settings that affect value decoding (subset of `AdsClientSettings`).
+ *
+ * NOTE: the settings object is captured by reference and the flags are read on every
+ * decode call - like `convertBufferToObject()` reads `this.settings` on every call.
+ * Changing `objectifyEnumerations` / `convertDatesToJavascript` on the fly (documented
+ * as OK on `Client.settings`) therefore affects already-compiled decoders too.
  */
 export interface CompiledDecoderSettings {
   /** If set, enumeration (ENUM) data types are converted to objects */
@@ -50,9 +55,14 @@ const NATIVE_READERS: Record<string, (data: Buffer, offset: number) => any> = {
   'UDINT': (data, offset) => data.readUInt32LE(offset),
   'REAL': (data, offset) => data.readFloatLE(offset),
   'LREAL': (data, offset) => data.readDoubleLE(offset),
-  'LWORD': (data, offset) => data.readBigUInt64LE(offset),
-  'LINT': (data, offset) => data.readBigInt64LE(offset),
 };
+
+//64-bit readers only where Buffer has BigInt support - elsewhere the base type's own
+//fromBuffer() fallback (returning the raw Buffer, like the interpreter) is used
+if (typeof Buffer.prototype.readBigInt64LE === 'function') {
+  NATIVE_READERS['LWORD'] = (data, offset) => data.readBigUInt64LE(offset);
+  NATIVE_READERS['LINT'] = (data, offset) => data.readBigInt64LE(offset);
+}
 
 /**
  * Signals that a data type contains a construct the compiler does not support.
@@ -63,9 +73,10 @@ class UnsupportedDataType extends Error { }
 /**
  * Compiles a decoder function for the given data type.
  *
- * The returned decoder produces output identical to `convertBufferToObject()`
- * (given the same `settings` and `attributes`) without re-walking the data type
- * metadata on every call.
+ * The returned decoder produces output identical to `convertBufferToObject()` without
+ * re-walking the data type metadata on every call. The `settings` object is captured
+ * by reference and its flags are read on every decode, so on-the-fly changes to
+ * `objectifyEnumerations` / `convertDatesToJavascript` are honored like the interpreter does.
  *
  * Returns `undefined` if the data type contains a construct the compiler does not
  * support - the caller should then fall back to `convertBufferToObject()`.
@@ -97,8 +108,9 @@ export const compileDataTypeDecoder = (dataType: AdsDataType, settings: Compiled
  * @param settings Decoding-related client settings
  * @param isArrayItem If `true`, this node is an array item (offsets relative to the element base)
  * @param attributes Symbol attributes (root node only, like in `convertBufferToObject()`)
+ * @param skipEnums If `true`, compile the non-enumeration variant of this node (used for the `objectifyEnumerations: false` alternative)
  */
-const compileNode = (dataType: AdsDataType, settings: CompiledDecoderSettings, isArrayItem: boolean, attributes?: AdsAttributeEntry[]): NodeDecoder => {
+const compileNode = (dataType: AdsDataType, settings: CompiledDecoderSettings, isArrayItem: boolean, attributes?: AdsAttributeEntry[], skipEnums: boolean = false): NodeDecoder => {
 
   if ((dataType.arrayInfos.length === 0 || isArrayItem) && dataType.subItems.length > 0) {
     //Struct or array item
@@ -148,11 +160,14 @@ const compileNode = (dataType: AdsDataType, settings: CompiledDecoderSettings, i
 
     return (data, base) => decodeDimension(data, base, 0, 0)[0];
 
-  } else if (dataType.enumInfos.length > 0 && settings.objectifyEnumerations) {
-    //Enumeration and objectifyEnumerations is enabled
+  } else if (dataType.enumInfos.length > 0 && !skipEnums) {
+    //Enumeration - objectifyEnumerations is read per call (it is documented as
+    //changeable on the fly), so both variants are compiled and selected at decode time.
     //Like convertBufferToObject(), known values resolve to the shared AdsEnumInfoEntry
     //object from the metadata (interned - safe, as these are never mutated)
+    const { offset } = dataType;
     const readValue = compilePrimitiveReader(dataType, settings);
+    const plain = compileNode(dataType, settings, isArrayItem, attributes, true);
     const entriesByValue = new Map<any, AdsEnumInfoEntry>();
 
     for (const entry of dataType.enumInfos) {
@@ -160,7 +175,10 @@ const compileNode = (dataType: AdsDataType, settings: CompiledDecoderSettings, i
     }
 
     return (data, base) => {
-      const value = readValue(data, base + dataType.offset);
+      if (!settings.objectifyEnumerations) {
+        return plain(data, base);
+      }
+      const value = readValue(data, base + offset);
       return entriesByValue.get(primitiveKey(value)) ?? { name: '', value } as AdsEnumInfoEntry;
     };
 
@@ -178,13 +196,13 @@ const compileNode = (dataType: AdsDataType, settings: CompiledDecoderSettings, i
     }
 
     const { offset, size } = dataType;
-    const convertDates = settings.convertDatesToJavascript;
     const fromBuffer = ADS.BASE_DATA_TYPES.find(type)?.fromBuffer;
 
     if (!fromBuffer) {
       throw new UnsupportedDataType(`Base type ${type} not found`);
     }
-    return (data, base) => fromBuffer(data.subarray(base + offset, base + offset + size) as never, convertDates);
+    //convertDatesToJavascript is read per call - it is documented as changeable on the fly
+    return (data, base) => fromBuffer(data.subarray(base + offset, base + offset + size) as never, settings.convertDatesToJavascript);
 
   } else if (dataType.flagsStr.includes('BitValues')) {
     //BIT (special case) - offset is in bits, relative to the parent scope
@@ -235,9 +253,9 @@ const compilePrimitiveReader = (dataType: AdsDataType, settings: CompiledDecoder
   }
 
   //No offset-native reader (e.g. DATE_AND_TIME) - fall back to the base type's
-  //own fromBuffer() on a subarray, resolved once here instead of per call
-  const convertDates = settings.convertDatesToJavascript;
-  return (data, offset) => type.fromBuffer(data.subarray(offset, offset + size) as never, convertDates);
+  //own fromBuffer() on a subarray, resolved once here instead of per call.
+  //convertDatesToJavascript is read per call - it is documented as changeable on the fly
+  return (data, offset) => type.fromBuffer(data.subarray(offset, offset + size) as never, settings.convertDatesToJavascript);
 };
 
 /**

--- a/src/compiled-decoder.ts
+++ b/src/compiled-decoder.ts
@@ -1,0 +1,247 @@
+import * as ADS from "./ads-commons";
+import type { AdsAttributeEntry, AdsDataType, AdsEnumInfoEntry } from "./types/ads-protocol-types";
+
+/**
+ * A compiled decoder converts raw PLC data to a Javascript object,
+ * exactly like `Client.convertBufferToObject()` does.
+ *
+ * `convertBufferToObject()` re-interprets the `AdsDataType` metadata tree on every
+ * call: property lookups, type dispatch, `subarray()` slices and enum searches for
+ * each member. The metadata is static per data type, so all of that work can be done
+ * once: `compileDataTypeDecoder()` partially evaluates the metadata into a tree of
+ * small closures with precomputed byte offsets, leaving only the buffer reads for
+ * runtime. For large structs read at high notification rates this is typically
+ * several times faster than the interpreting path.
+ */
+export type CompiledDecoder = (data: Buffer) => any;
+
+/**
+ * Settings that affect value decoding (subset of `AdsClientSettings`).
+ */
+export interface CompiledDecoderSettings {
+  /** If set, enumeration (ENUM) data types are converted to objects */
+  objectifyEnumerations: boolean,
+  /** If set, PLC date types are converted to Javascript `Date` objects */
+  convertDatesToJavascript: boolean
+}
+
+/**
+ * A decoder for a node of the data type tree.
+ * `base` is the absolute byte offset of the node's parent scope in `data`.
+ */
+type NodeDecoder = (data: Buffer, base: number) => any;
+
+/**
+ * Offset-native readers for base types whose value is a pure number/boolean/bigint,
+ * keyed by the canonical (first) name of the `ADS.BASE_DATA_TYPES` entry.
+ * Everything else falls back to the entry's own `fromBuffer()` on a subarray.
+ *
+ * NOTE: `TIME`/`TOD` alias `UDINT` and `LTIME` aliases `LWORD` in `BASE_DATA_TYPES`,
+ * so they are covered here. `DATE_AND_TIME`/`DT`/`DATE` have their own entry with
+ * date conversion and take the fallback path.
+ */
+const NATIVE_READERS: Record<string, (data: Buffer, offset: number) => any> = {
+  'BOOL': (data, offset) => data.readUInt8(offset) !== 0,
+  'BYTE': (data, offset) => data.readUInt8(offset),
+  'SINT': (data, offset) => data.readInt8(offset),
+  'UINT': (data, offset) => data.readUInt16LE(offset),
+  'INT': (data, offset) => data.readInt16LE(offset),
+  'DINT': (data, offset) => data.readInt32LE(offset),
+  'UDINT': (data, offset) => data.readUInt32LE(offset),
+  'REAL': (data, offset) => data.readFloatLE(offset),
+  'LREAL': (data, offset) => data.readDoubleLE(offset),
+  'LWORD': (data, offset) => data.readBigUInt64LE(offset),
+  'LINT': (data, offset) => data.readBigInt64LE(offset),
+};
+
+/**
+ * Signals that a data type contains a construct the compiler does not support.
+ * The caller is expected to fall back to `convertBufferToObject()`.
+ */
+class UnsupportedDataType extends Error { }
+
+/**
+ * Compiles a decoder function for the given data type.
+ *
+ * The returned decoder produces output identical to `convertBufferToObject()`
+ * (given the same `settings` and `attributes`) without re-walking the data type
+ * metadata on every call.
+ *
+ * Returns `undefined` if the data type contains a construct the compiler does not
+ * support - the caller should then fall back to `convertBufferToObject()`.
+ *
+ * @param dataType The data type to compile a decoder for (as built by `Client.buildDataType()`)
+ * @param settings Decoding-related client settings
+ * @param attributes Additional attributes of the symbol used for conversion (as `convertBufferToObject()` receives them - only applied to the root node)
+ */
+export const compileDataTypeDecoder = (dataType: AdsDataType, settings: CompiledDecoderSettings, attributes?: AdsAttributeEntry[]): CompiledDecoder | undefined => {
+  try {
+    const decoder = compileNode(dataType, settings, false, attributes);
+    return (data: Buffer) => decoder(data, 0);
+
+  } catch (err) {
+    if (err instanceof UnsupportedDataType) {
+      return undefined;
+    }
+    throw err;
+  }
+};
+
+/**
+ * Compiles a decoder for one node of the data type tree.
+ *
+ * Mirrors the branch structure of `Client.convertBufferToObject()` - each branch
+ * here must produce the same result as the corresponding branch there.
+ *
+ * @param dataType Data type of this node
+ * @param settings Decoding-related client settings
+ * @param isArrayItem If `true`, this node is an array item (offsets relative to the element base)
+ * @param attributes Symbol attributes (root node only, like in `convertBufferToObject()`)
+ */
+const compileNode = (dataType: AdsDataType, settings: CompiledDecoderSettings, isArrayItem: boolean, attributes?: AdsAttributeEntry[]): NodeDecoder => {
+
+  if ((dataType.arrayInfos.length === 0 || isArrayItem) && dataType.subItems.length > 0) {
+    //Struct or array item
+    //convertBufferToObject() slices the buffer to dataType.offset and lets each
+    //subitem apply its own offset - here that becomes a base offset for the children
+    const structOffset = dataType.offset;
+    const names = dataType.subItems.map(item => item.name);
+    const decoders = dataType.subItems.map(item => compileNode(item, settings, false));
+    const count = names.length;
+
+    return (data, base) => {
+      const result: Record<string, any> = {};
+      const childBase = base + structOffset;
+
+      for (let i = 0; i < count; i++) {
+        result[names[i]] = decoders[i](data, childBase);
+      }
+      return result;
+    };
+
+  } else if (dataType.arrayInfos.length > 0 && !isArrayItem) {
+    //Array
+    const elementSize = dataType.size;
+    const element = compileNode(dataType, settings, true);
+    const dimensions = dataType.arrayInfos.map(info => info.length);
+
+    //convertBufferToObject() does NOT apply dataType.offset in its array branch -
+    //each element applies the offset itself (also for primitive elements).
+    //Element i therefore starts at base + i * size, with the element decoder
+    //adding dataType.offset internally.
+    const decodeDimension = (data: Buffer, base: number, dim: number, flatIndex: number): [any[], number] => {
+      const result = [];
+
+      for (let i = 0; i < dimensions[dim]; i++) {
+        if (dim + 1 < dimensions.length) {
+          const [value, nextIndex] = decodeDimension(data, base, dim + 1, flatIndex);
+          result.push(value);
+          flatIndex = nextIndex;
+
+        } else {
+          result.push(element(data, base + flatIndex * elementSize));
+          flatIndex++;
+        }
+      }
+      return [result, flatIndex];
+    };
+
+    return (data, base) => decodeDimension(data, base, 0, 0)[0];
+
+  } else if (dataType.enumInfos.length > 0 && settings.objectifyEnumerations) {
+    //Enumeration and objectifyEnumerations is enabled
+    //Like convertBufferToObject(), known values resolve to the shared AdsEnumInfoEntry
+    //object from the metadata (interned - safe, as these are never mutated)
+    const readValue = compilePrimitiveReader(dataType, settings);
+    const entriesByValue = new Map<any, AdsEnumInfoEntry>();
+
+    for (const entry of dataType.enumInfos) {
+      entriesByValue.set(primitiveKey(entry.value), entry);
+    }
+
+    return (data, base) => {
+      const value = readValue(data, base + dataType.offset);
+      return entriesByValue.get(primitiveKey(value)) ?? { name: '', value } as AdsEnumInfoEntry;
+    };
+
+  } else if (dataType.adsDataType === ADS.ADS_DATA_TYPES.ADST_BIGTYPE && dataType.subItems.length === 0) {
+    if (dataType.size === 0) {
+      //Empty STRUCT
+      return () => ({});
+    }
+
+    //Empty FUNCTION_BLOCK or INTERFACE - handled like a pointer
+    const type = ADS.BASE_DATA_TYPES.getTypeByPseudoType('PVOID', dataType.size);
+
+    if (!type) {
+      throw new UnsupportedDataType(`No pseudo type PVOID of size ${dataType.size}`);
+    }
+
+    const { offset, size } = dataType;
+    const convertDates = settings.convertDatesToJavascript;
+    const fromBuffer = ADS.BASE_DATA_TYPES.find(type)?.fromBuffer;
+
+    if (!fromBuffer) {
+      throw new UnsupportedDataType(`Base type ${type} not found`);
+    }
+    return (data, base) => fromBuffer(data.subarray(base + offset, base + offset + size) as never, convertDates);
+
+  } else if (dataType.flagsStr.includes('BitValues')) {
+    //BIT (special case) - offset is in bits, relative to the parent scope
+    const byteOffset = Math.floor(dataType.offset / 8);
+    const bitMask = 1 << (dataType.offset % 8);
+
+    return (data, base) => !!(data.readUInt8(base + byteOffset) & bitMask);
+
+  } else {
+    //Primitive type
+    const { offset } = dataType;
+    const readValue = compilePrimitiveReader(dataType, settings, attributes);
+
+    return (data, base) => readValue(data, base + offset);
+  }
+};
+
+/**
+ * Compiles an offset-taking reader equivalent to `Client.convertBufferToPrimitiveType()`
+ * for the given data type, resolving the base type and string encoding at compile time.
+ */
+const compilePrimitiveReader = (dataType: AdsDataType, settings: CompiledDecoderSettings, attributes?: AdsAttributeEntry[]): ((data: Buffer, offset: number) => any) => {
+  const { size } = dataType;
+
+  if (dataType.adsDataType === ADS.ADS_DATA_TYPES.ADST_STRING) {
+    //Encoding resolution as in getStringDataTypeEncoding()
+    const encoding = dataType.attributes.find((attr) => attr.name === 'TcEncoding')?.value
+      ?? attributes?.find((attr) => attr.name === 'TcEncoding')?.value;
+    const utf8 = encoding === 'UTF-8';
+
+    return (data, offset) => ADS.decodePlcStringBuffer(data.subarray(offset, offset + size), utf8);
+  }
+
+  if (dataType.adsDataType === ADS.ADS_DATA_TYPES.ADST_WSTRING) {
+    return (data, offset) => ADS.decodePlcWstringBuffer(data.subarray(offset, offset + size));
+  }
+
+  const type = ADS.BASE_DATA_TYPES.find(dataType.type);
+
+  if (!type) {
+    throw new UnsupportedDataType(`Base type ${dataType.type} not found`);
+  }
+
+  const nativeReader = NATIVE_READERS[type.name[0]];
+
+  if (nativeReader && type.size === size) {
+    return nativeReader;
+  }
+
+  //No offset-native reader (e.g. DATE_AND_TIME) - fall back to the base type's
+  //own fromBuffer() on a subarray, resolved once here instead of per call
+  const convertDates = settings.convertDatesToJavascript;
+  return (data, offset) => type.fromBuffer(data.subarray(offset, offset + size) as never, convertDates);
+};
+
+/**
+ * Map key for an enum underlying value - BigInt values (LINT-based enums)
+ * cannot be used as Map keys interchangeably with numbers, so normalize.
+ */
+const primitiveKey = (value: any): any => typeof value === 'bigint' ? value.toString() : value;

--- a/src/types/ads-client-types.ts
+++ b/src/types/ads-client-types.ts
@@ -455,7 +455,11 @@ export interface AdsClientSettings {
    * subscribing to large structs with fast cycle times.
    *
    * Data types with constructs not supported by the decoder compiler are automatically converted
-   * the regular way. Has no effect if `disableCaching` is set.
+   * the regular way.
+   *
+   * Compiled decoders piggyback on the built data type cache, so they only apply where that
+   * cache applies: this setting has no effect if `disableCaching` is set, and calls with
+   * `targetOpts` target overrides always use the regular conversion.
    */
   useCompiledDecoders?: boolean
 }

--- a/src/types/ads-client-types.ts
+++ b/src/types/ads-client-types.ts
@@ -442,7 +442,22 @@ export interface AdsClientSettings {
    * 
    * When connecting to a non-PLC system with UTF-8 encoded ADS symbols, this setting needs to be set.
    */
-  forceUtf8ForAdsSymbols?: boolean
+  forceUtf8ForAdsSymbols?: boolean,
+
+  /**
+   * **Optional**: If set, raw values are converted to Javascript objects using compiled decoders (default: `false`).
+   *
+   * When reading a value (or receiving a subscription notification), the raw data is converted using
+   * a decoder function that is compiled once for each data type and then cached, instead of
+   * interpreting the data type metadata again on every conversion.
+   *
+   * The result is identical, but conversion is typically several times faster - which matters when
+   * subscribing to large structs with fast cycle times.
+   *
+   * Data types with constructs not supported by the decoder compiler are automatically converted
+   * the regular way. Has no effect if `disableCaching` is set.
+   */
+  useCompiledDecoders?: boolean
 }
 
 /**

--- a/test/compiled-decoder.test.js
+++ b/test/compiled-decoder.test.js
@@ -231,6 +231,19 @@ describe('Client.decodeBufferToObject', () => {
     expect(client['decodeBufferToObject'](data, dataType)).toBe(42);
   });
 
+  test('skips the compiled path for targetOpts overrides (data type cache does not apply)', () => {
+    const client = makeClient({ useCompiledDecoders: true });
+    const dataType = mixedStructType();
+    const data = mixedStructBuffer();
+
+    //With targetOpts, buildDataType() returns a fresh AdsDataType per call, so caching
+    //a decoder (keyed by object identity) would silently recompile on every call
+    const result = client['decodeBufferToObject'](data, dataType, undefined, { amsNetId: '192.168.4.2.1.1' });
+
+    expect(result).toStrictEqual(client['convertBufferToObject'](data, dataType));
+    expect(client['compiledDecoders'].has(dataType)).toBe(false);
+  });
+
   test('is disabled by default', () => {
     const client = makeClient();
 

--- a/test/compiled-decoder.test.js
+++ b/test/compiled-decoder.test.js
@@ -218,17 +218,91 @@ describe('Client.decodeBufferToObject', () => {
     expect(client['decodeBufferToObject'](data, dataType)).toStrictEqual(interpreted); //Cached path
   });
 
-  test('falls back to the interpreter when compilation is not possible', () => {
+  test('routes uncompilable types to the interpreter', () => {
     const client = makeClient({ useCompiledDecoders: true });
-    const dataType = makeType({ name: 'INT', type: 'INT', adsDataType: T.ADST_INT16, size: 2 });
-    //Sabotage compilation by making the base type unresolvable, then restore
-    const brokenType = { ...dataType, type: 'SOME_UNKNOWN_TYPE' };
+    const brokenType = makeType({ name: 'INT', type: 'SOME_UNKNOWN_TYPE', adsDataType: T.ADST_INT16, size: 2 });
     const data = Buffer.alloc(2);
-    data.writeInt16LE(42, 0);
 
     expect(compileDataTypeDecoder(brokenType, client.settings)).toBeUndefined();
-    expect(() => client['decodeBufferToObject'](data, dataType)).not.toThrow();
-    expect(client['decodeBufferToObject'](data, dataType)).toBe(42);
+    //NOTE: all currently-known uncompilable constructs also throw in the interpreter,
+    //so this asserts the ROUTING (the interpreter's error, not a compiler error), and
+    //that the failed compilation result is cached
+    expect(() => client['decodeBufferToObject'](data, brokenType)).toThrow(/Base type SOME_UNKNOWN_TYPE not found/);
+    expect(client['compiledDecoders'].has(brokenType)).toBe(true);
+    expect(client['compiledDecoders'].get(brokenType)).toBeUndefined();
+  });
+
+  test('honors on-the-fly settings changes on already-compiled decoders (like the interpreter)', () => {
+    const client = makeClient({ useCompiledDecoders: true });
+    const dataType = mixedStructType();
+    const data = mixedStructBuffer(5);
+
+    const before = client['decodeBufferToObject'](data, dataType);
+    expect(before.eMode).toEqual({ name: 'B', value: 5 });
+    expect(before.dtDate).toBeInstanceOf(Date);
+
+    //Documented usage: client.settings.convertDatesToJavascript = false; //OK
+    client.settings.objectifyEnumerations = false;
+    client.settings.convertDatesToJavascript = false;
+
+    const after = client['decodeBufferToObject'](data, dataType);
+    expect(after).toStrictEqual(client['convertBufferToObject'](data, dataType));
+    expect(after.eMode).toBe(5);
+    expect(typeof after.dtDate).toBe('number');
+    //Same cached decoder served both calls
+    expect(client['compiledDecoders'].get(dataType)).toBeDefined();
+  });
+
+  test('decodes empty structs like the interpreter', () => {
+    const client = makeClient();
+    const dataType = makeType({ name: 'ST_Empty', type: 'ST_Empty', adsDataType: T.ADST_BIGTYPE, size: 0 });
+    const decoded = compileDataTypeDecoder(dataType, client.settings)(Buffer.alloc(0));
+
+    expect(decoded).toStrictEqual(client['convertBufferToObject'](Buffer.alloc(0), dataType));
+    expect(decoded).toEqual({});
+  });
+
+  test('decodes nested STRING members with type-level TcEncoding like the interpreter', () => {
+    const client = makeClient({ useCompiledDecoders: true });
+    const dataType = makeType({
+      name: 'ST_Enc', type: 'ST_Enc', adsDataType: T.ADST_BIGTYPE, size: 16,
+      subItems: [makeType({
+        name: 'sUtf8', type: 'STRING(15)', adsDataType: T.ADST_STRING, size: 16, offset: 0,
+        attributes: [{ name: 'TcEncoding', value: 'UTF-8' }] //On the data type, not the symbol
+      })]
+    });
+    const data = Buffer.alloc(16);
+    Buffer.from('smörgås\0', 'utf8').copy(data, 0);
+
+    const decoded = client['decodeBufferToObject'](data, dataType);
+    expect(decoded).toStrictEqual(client['convertBufferToObject'](data, dataType));
+    expect(decoded.sUtf8).toBe('smörgås');
+    expect(client['compiledDecoders'].has(dataType)).toBe(true); //Type-level encoding does not skip compilation
+  });
+
+  test('skips the compiled path only for TcEncoding symbol attributes on STRING roots', () => {
+    const client = makeClient({ useCompiledDecoders: true });
+    const attributes = [{ name: 'TcEncoding', value: 'UTF-8' }];
+
+    //STRING root + symbol TcEncoding: attributes affect decoding -> interpreter
+    const stringType = makeType({ name: 'STRING(15)', type: 'STRING(15)', adsDataType: T.ADST_STRING, size: 16 });
+    client['decodeBufferToObject'](Buffer.alloc(16), stringType, attributes);
+    expect(client['compiledDecoders'].has(stringType)).toBe(false);
+
+    //Struct root + symbol TcEncoding: attributes cannot affect decoding -> compiled path
+    const structType = mixedStructType();
+    const decoded = client['decodeBufferToObject'](mixedStructBuffer(), structType, attributes);
+    expect(client['compiledDecoders'].has(structType)).toBe(true);
+    expect(decoded).toStrictEqual(client['convertBufferToObject'](mixedStructBuffer(), structType, attributes));
+  });
+
+  test('skips the compiled path when disableCaching is set', () => {
+    const client = makeClient({ useCompiledDecoders: true, disableCaching: true });
+    const dataType = mixedStructType();
+
+    const decoded = client['decodeBufferToObject'](mixedStructBuffer(), dataType);
+    expect(decoded).toStrictEqual(client['convertBufferToObject'](mixedStructBuffer(), dataType));
+    expect(client['compiledDecoders'].has(dataType)).toBe(false);
   });
 
   test('skips the compiled path for targetOpts overrides (data type cache does not apply)', () => {
@@ -246,10 +320,12 @@ describe('Client.decodeBufferToObject', () => {
 
   test('is disabled by default', () => {
     const client = makeClient();
+    const dataType = mixedStructType();
 
     expect(client.settings.useCompiledDecoders).toBe(false);
-    client['decodeBufferToObject'](mixedStructBuffer(), mixedStructType());
-    expect(client['compiledDecoders'].has(mixedStructType())).toBe(false);
+    client['decodeBufferToObject'](mixedStructBuffer(), dataType);
+    //Same object for call and check - WeakMap is identity-keyed
+    expect(client['compiledDecoders'].has(dataType)).toBe(false);
   });
 
   test('compiled decoding is substantially faster than interpreting', () => {
@@ -309,6 +385,8 @@ describe('Client.decodeBufferToObject', () => {
     const interpretedUs = Number(t2 - t1) / N / 1000;
     console.info(`compiled: ${compiledUs.toFixed(2)} µs/op, interpreted: ${interpretedUs.toFixed(2)} µs/op, ${(interpretedUs / compiledUs).toFixed(1)}x`);
 
-    expect(interpretedUs / compiledUs).toBeGreaterThan(2);
+    //Deliberately loose (typical ratio is 4-5x) - this guards against the compiled path
+    //regressing to interpreter speed, without being flaky under CI load
+    expect(interpretedUs / compiledUs).toBeGreaterThan(1.3);
   });
 });

--- a/test/compiled-decoder.test.js
+++ b/test/compiled-decoder.test.js
@@ -1,0 +1,301 @@
+/**
+ * Tests for the compiled decoder (settings.useCompiledDecoders).
+ *
+ * Verifies that compiled decoders produce output identical to
+ * Client.convertBufferToObject() using synthetic data type metadata
+ * (shaped like Client.buildDataType() output). Runs standalone -
+ * no PLC connection needed.
+ *
+ * Run: npx jest test/compiled-decoder.test.js
+ */
+const { Client } = require('../dist/ads-client');
+const { compileDataTypeDecoder } = require('../dist/compiled-decoder');
+const ADS = require('../dist/ads-commons');
+
+/** Creates an AdsDataType object with defaults (shaped like buildDataType() output) */
+const makeType = (props) => ({
+  version: 1,
+  hashValue: 0,
+  typeHashValue: 0,
+  size: 0,
+  offset: 0,
+  adsDataType: 0,
+  adsDataTypeStr: '',
+  flags: 0,
+  flagsStr: [],
+  arrayDimension: 0,
+  name: '',
+  type: '',
+  comment: '',
+  arrayInfos: [],
+  subItems: [],
+  typeGuid: '',
+  rpcMethods: [],
+  attributes: [],
+  enumInfos: [],
+  extendedFlags: 0,
+  reserved: Buffer.alloc(0),
+  ...props
+});
+
+const T = ADS.ADS_DATA_TYPES;
+
+/** ST_Point: {x: REAL, y: REAL} - 8 bytes */
+const pointSubItems = () => [
+  makeType({ name: 'x', type: 'REAL', adsDataType: T.ADST_REAL32, size: 4, offset: 0 }),
+  makeType({ name: 'y', type: 'REAL', adsDataType: T.ADST_REAL32, size: 4, offset: 4 }),
+];
+
+/**
+ * A struct exercising every decoder branch: primitives of all widths, strings,
+ * enums (known + unknown value), TIME/DT, nested struct, arrays (primitive,
+ * struct, 2D) and BitValues bits. 152 bytes.
+ */
+const mixedStructType = () => makeType({
+  name: 'ST_Mixed',
+  adsDataType: T.ADST_BIGTYPE,
+  size: 152,
+  subItems: [
+    makeType({ name: 'bBool', type: 'BOOL', adsDataType: T.ADST_BIT, size: 1, offset: 0 }),
+    makeType({ name: 'nByte', type: 'BYTE', adsDataType: T.ADST_UINT8, size: 1, offset: 1 }),
+    makeType({ name: 'nInt', type: 'INT', adsDataType: T.ADST_INT16, size: 2, offset: 2 }),
+    makeType({ name: 'nUInt', type: 'UINT', adsDataType: T.ADST_UINT16, size: 2, offset: 4 }),
+    makeType({ name: 'nDInt', type: 'DINT', adsDataType: T.ADST_INT32, size: 4, offset: 8 }),
+    makeType({ name: 'nUDInt', type: 'UDINT', adsDataType: T.ADST_UINT32, size: 4, offset: 12 }),
+    makeType({ name: 'fReal', type: 'REAL', adsDataType: T.ADST_REAL32, size: 4, offset: 16 }),
+    makeType({ name: 'fLReal', type: 'LREAL', adsDataType: T.ADST_REAL64, size: 8, offset: 24 }),
+    makeType({ name: 'nLInt', type: 'LINT', adsDataType: T.ADST_INT64, size: 8, offset: 32 }),
+    makeType({ name: 'nLWord', type: 'LWORD', adsDataType: T.ADST_UINT64, size: 8, offset: 40 }),
+    makeType({ name: 'sStr', type: 'STRING(15)', adsDataType: T.ADST_STRING, size: 16, offset: 48 }),
+    makeType({ name: 'wStr', type: 'WSTRING(5)', adsDataType: T.ADST_WSTRING, size: 12, offset: 64 }),
+    makeType({
+      name: 'eMode', type: 'INT', adsDataType: T.ADST_INT16, size: 2, offset: 76,
+      enumInfos: [{ name: 'A', value: 0 }, { name: 'B', value: 5 }, { name: 'C', value: 10 }]
+    }),
+    makeType({ name: 'tTime', type: 'TIME', adsDataType: T.ADST_UINT32, size: 4, offset: 80 }),
+    makeType({ name: 'dtDate', type: 'DT', adsDataType: T.ADST_UINT32, size: 4, offset: 84 }),
+    makeType({
+      name: 'stInner', type: 'ST_Point', adsDataType: T.ADST_BIGTYPE, size: 8, offset: 88,
+      subItems: pointSubItems()
+    }),
+    makeType({
+      name: 'aInts', type: 'INT', adsDataType: T.ADST_INT16, size: 2, offset: 100,
+      arrayDimension: 1, arrayInfos: [{ startIndex: 0, length: 4 }]
+    }),
+    makeType({
+      name: 'aPoints', type: 'ST_Point', adsDataType: T.ADST_BIGTYPE, size: 8, offset: 108,
+      arrayDimension: 1, arrayInfos: [{ startIndex: 0, length: 2 }],
+      subItems: pointSubItems()
+    }),
+    makeType({
+      name: 'a2d', type: 'UDINT', adsDataType: T.ADST_UINT32, size: 4, offset: 124,
+      arrayDimension: 2, arrayInfos: [{ startIndex: 0, length: 2 }, { startIndex: 0, length: 3 }]
+    }),
+    //BitValues: offset is in bits (148 bytes = 1184 bits)
+    makeType({ name: 'bFlag0', type: 'BOOL', adsDataType: T.ADST_BIT, size: 1, offset: 1184, flagsStr: ['BitValues'] }),
+    makeType({ name: 'bFlag3', type: 'BOOL', adsDataType: T.ADST_BIT, size: 1, offset: 1187, flagsStr: ['BitValues'] }),
+  ]
+});
+
+/** Builds a buffer matching mixedStructType() with non-trivial values */
+const mixedStructBuffer = (enumValue = 5) => {
+  const data = Buffer.alloc(152);
+  data.writeUInt8(1, 0); //bBool
+  data.writeUInt8(200, 1); //nByte
+  data.writeInt16LE(-12345, 2); //nInt
+  data.writeUInt16LE(54321, 4); //nUInt
+  data.writeInt32LE(-7654321, 8); //nDInt
+  data.writeUInt32LE(4000000000, 12); //nUDInt
+  data.writeFloatLE(3.25, 16); //fReal
+  data.writeDoubleLE(-2.5e42, 24); //fLReal
+  data.writeBigInt64LE(-1234567890123456789n, 32); //nLInt
+  data.writeBigUInt64LE(18446744073709551615n, 40); //nLWord
+  Buffer.from('hello\0garbage!', 'latin1').copy(data, 48); //sStr (null-terminated + garbage)
+  Buffer.from('wide\0', 'utf16le').copy(data, 64); //wStr
+  data.writeInt16LE(enumValue, 76); //eMode
+  data.writeUInt32LE(123456, 80); //tTime
+  data.writeUInt32LE(1700000000, 84); //dtDate (epoch seconds)
+  data.writeFloatLE(1.5, 88); data.writeFloatLE(-1.5, 92); //stInner
+  [10, -20, 30, -40].forEach((v, i) => data.writeInt16LE(v, 100 + i * 2)); //aInts
+  [0.5, 1.5, 2.5, 3.5].forEach((v, i) => data.writeFloatLE(v, 108 + i * 4)); //aPoints
+  [1, 2, 3, 4, 5, 6].forEach((v, i) => data.writeUInt32LE(v, 124 + i * 4)); //a2d
+  data.writeUInt8(0b00001001, 148); //bFlag0 = true, bFlag3 = true
+  return data;
+};
+
+const makeClient = (settings = {}) => new Client({
+  targetAmsNetId: '192.168.4.1.1.1',
+  targetAdsPort: 851,
+  ...settings
+});
+
+const SETTING_VARIANTS = [
+  { objectifyEnumerations: true, convertDatesToJavascript: true },
+  { objectifyEnumerations: false, convertDatesToJavascript: true },
+  { objectifyEnumerations: true, convertDatesToJavascript: false },
+  { objectifyEnumerations: false, convertDatesToJavascript: false },
+];
+
+describe('compileDataTypeDecoder', () => {
+
+  test.each(SETTING_VARIANTS)('matches convertBufferToObject() (%o)', (settings) => {
+    const client = makeClient(settings);
+    const dataType = mixedStructType();
+    const data = mixedStructBuffer();
+
+    const interpreted = client['convertBufferToObject'](data, dataType);
+    const decoder = compileDataTypeDecoder(dataType, client.settings);
+
+    expect(decoder).toBeDefined();
+    expect(decoder(data)).toStrictEqual(interpreted);
+  });
+
+  test('matches convertBufferToObject() for unknown enum values', () => {
+    const client = makeClient();
+    const dataType = mixedStructType();
+    const data = mixedStructBuffer(7); //7 is not a valid eMode value
+
+    const decoded = compileDataTypeDecoder(dataType, client.settings)(data);
+
+    expect(decoded).toStrictEqual(client['convertBufferToObject'](data, dataType));
+    expect(decoded.eMode).toEqual({ name: '', value: 7 });
+  });
+
+  test('returns the shared enum entry object for known values (like the interpreter)', () => {
+    const client = makeClient();
+    const dataType = mixedStructType();
+    const data = mixedStructBuffer(5);
+
+    const decoded = compileDataTypeDecoder(dataType, client.settings)(data);
+    const enumEntry = dataType.subItems.find(item => item.name === 'eMode').enumInfos[1];
+
+    expect(decoded.eMode).toBe(enumEntry); //Identity, not just equality
+    expect(client['convertBufferToObject'](data, dataType).eMode).toBe(enumEntry);
+  });
+
+  test('decodes primitives at the top level (no struct)', () => {
+    const client = makeClient();
+    const dataType = makeType({ name: 'LREAL', type: 'LREAL', adsDataType: T.ADST_REAL64, size: 8 });
+    const data = Buffer.alloc(8);
+    data.writeDoubleLE(123.456, 0);
+
+    expect(compileDataTypeDecoder(dataType, client.settings)(data))
+      .toStrictEqual(client['convertBufferToObject'](data, dataType));
+  });
+
+  test('applies UTF-8 string encoding from symbol attributes (root only, like the interpreter)', () => {
+    const client = makeClient();
+    const dataType = makeType({ name: 'STRING(15)', type: 'STRING(15)', adsDataType: T.ADST_STRING, size: 16 });
+    const attributes = [{ name: 'TcEncoding', value: 'UTF-8' }];
+    const data = Buffer.alloc(16);
+    Buffer.from('höyry\0', 'utf8').copy(data, 0);
+
+    const decoded = compileDataTypeDecoder(dataType, client.settings, attributes)(data);
+
+    expect(decoded).toBe('höyry');
+    expect(decoded).toStrictEqual(client['convertBufferToObject'](data, dataType, attributes));
+  });
+
+  test('returns undefined for unsupported constructs', () => {
+    const client = makeClient();
+    const dataType = makeType({ name: 'ST_Weird', type: 'SOME_UNKNOWN_TYPE', adsDataType: 999, size: 4 });
+
+    expect(compileDataTypeDecoder(dataType, client.settings)).toBeUndefined();
+  });
+});
+
+describe('Client.decodeBufferToObject', () => {
+
+  test('uses the compiled decoder when useCompiledDecoders is set and caches it', () => {
+    const client = makeClient({ useCompiledDecoders: true });
+    const dataType = mixedStructType();
+    const data = mixedStructBuffer();
+
+    const interpreted = client['convertBufferToObject'](data, dataType);
+
+    expect(client['decodeBufferToObject'](data, dataType)).toStrictEqual(interpreted);
+    expect(client['compiledDecoders'].has(dataType)).toBe(true);
+    expect(client['decodeBufferToObject'](data, dataType)).toStrictEqual(interpreted); //Cached path
+  });
+
+  test('falls back to the interpreter when compilation is not possible', () => {
+    const client = makeClient({ useCompiledDecoders: true });
+    const dataType = makeType({ name: 'INT', type: 'INT', adsDataType: T.ADST_INT16, size: 2 });
+    //Sabotage compilation by making the base type unresolvable, then restore
+    const brokenType = { ...dataType, type: 'SOME_UNKNOWN_TYPE' };
+    const data = Buffer.alloc(2);
+    data.writeInt16LE(42, 0);
+
+    expect(compileDataTypeDecoder(brokenType, client.settings)).toBeUndefined();
+    expect(() => client['decodeBufferToObject'](data, dataType)).not.toThrow();
+    expect(client['decodeBufferToObject'](data, dataType)).toBe(42);
+  });
+
+  test('is disabled by default', () => {
+    const client = makeClient();
+
+    expect(client.settings.useCompiledDecoders).toBe(false);
+    client['decodeBufferToObject'](mixedStructBuffer(), mixedStructType());
+    expect(client['compiledDecoders'].has(mixedStructType())).toBe(false);
+  });
+
+  test('compiled decoding is substantially faster than interpreting', () => {
+    const client = makeClient();
+    //Realistic subscription shape: deeply nested numeric/bool struct (like an
+    //axis/drive status), where metadata interpretation dominates - strings would
+    //compress the ratio as iconv decoding costs the same on both paths
+    const axis = () => makeType({
+      name: 'ST_Axis', type: 'ST_Axis', adsDataType: T.ADST_BIGTYPE, size: 40,
+      subItems: [
+        makeType({ name: 'bEnabled', type: 'BOOL', adsDataType: T.ADST_BIT, size: 1, offset: 0 }),
+        makeType({ name: 'bHomed', type: 'BOOL', adsDataType: T.ADST_BIT, size: 1, offset: 1 }),
+        makeType({
+          name: 'eState', type: 'INT', adsDataType: T.ADST_INT16, size: 2, offset: 2,
+          enumInfos: [{ name: 'IDLE', value: 0 }, { name: 'MOVING', value: 1 }, { name: 'ERROR', value: 2 }]
+        }),
+        makeType({ name: 'nErrorId', type: 'UDINT', adsDataType: T.ADST_UINT32, size: 4, offset: 4 }),
+        makeType({ name: 'fPosition', type: 'LREAL', adsDataType: T.ADST_REAL64, size: 8, offset: 8 }),
+        makeType({ name: 'fVelocity', type: 'LREAL', adsDataType: T.ADST_REAL64, size: 8, offset: 16 }),
+        makeType({ name: 'fTorque', type: 'LREAL', adsDataType: T.ADST_REAL64, size: 8, offset: 24 }),
+        makeType({
+          name: 'Inputs', type: 'ST_Inputs', adsDataType: T.ADST_BIGTYPE, size: 8, offset: 32,
+          subItems: [0, 1, 2, 3, 4, 5, 6, 7].map(i =>
+            makeType({ name: `bIn${i}`, type: 'BOOL', adsDataType: T.ADST_BIT, size: 1, offset: i }))
+        }),
+      ]
+    });
+    const dataType = makeType({
+      name: 'ST_Status', type: 'ST_Status', adsDataType: T.ADST_BIGTYPE, size: 168,
+      subItems: [
+        makeType({ name: 'bHasError', type: 'BOOL', adsDataType: T.ADST_BIT, size: 1, offset: 0 }),
+        makeType({ ...axis(), name: 'Horizontal', offset: 8 }),
+        makeType({ ...axis(), name: 'Vertical', offset: 48 }),
+        makeType({ ...axis(), name: 'Gripper', offset: 88 }),
+        makeType({ ...axis(), name: 'ZAxis', offset: 128 }),
+      ]
+    });
+    const data = Buffer.alloc(168);
+    for (let i = 0; i < 168; i++) data.writeUInt8((i * 7) % 250, i);
+    const decoder = compileDataTypeDecoder(dataType, client.settings);
+    expect(decoder(data)).toStrictEqual(client['convertBufferToObject'](data, dataType));
+    const N = 2000;
+
+    //Warmup
+    for (let i = 0; i < 200; i++) {
+      decoder(data);
+      client['convertBufferToObject'](data, dataType);
+    }
+
+    const t0 = process.hrtime.bigint();
+    for (let i = 0; i < N; i++) decoder(data);
+    const t1 = process.hrtime.bigint();
+    for (let i = 0; i < N; i++) client['convertBufferToObject'](data, dataType);
+    const t2 = process.hrtime.bigint();
+
+    const compiledUs = Number(t1 - t0) / N / 1000;
+    const interpretedUs = Number(t2 - t1) / N / 1000;
+    console.info(`compiled: ${compiledUs.toFixed(2)} µs/op, interpreted: ${interpretedUs.toFixed(2)} µs/op, ${(interpretedUs / compiledUs).toFixed(1)}x`);
+
+    expect(interpretedUs / compiledUs).toBeGreaterThan(2);
+  });
+});


### PR DESCRIPTION
In our project with 12 connected PLCs @ 100 hz, the interpreter `convertBufferToObject` dominates CPU profiles.

Claude Fable suggested a possible optimization: Compile a decoder per data type _once_. Compiling here means partially evaluating symbol metadata into a tree of small closures with the exact offsets, effectively skipping a lot of repeated interpretation.

This approach freed up 19% of a CPU core here, so I'm offering the optimization as an opt-in option: `useCompiledDecoders`.

Will paste the writeup by Claude Fable below.